### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.static-backgrounds
+++ b/Dockerfile.static-backgrounds
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+EXPOSE 80

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO wavy-curvey-blobby-website
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: wavy-curvey-blobby-website
+
+static-backgrounds:
+  defines: runnable
+  metadata:
+    name: static-backgrounds
+    description: A static website with examples of styled backgrounds.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    static-backgrounds:
+      image: env-3296.registry.local/static-backgrounds:main-86203a0
+      build: .
+      dockerfile: Dockerfile.static-backgrounds
+  services:
+    http:
+      description: HTTP web server port
+      container: static-backgrounds
+      port: 80
+      host-port: 80
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - wavy-curvey-blobby-website/static-backgrounds


### PR DESCRIPTION
# PR Description for Containerization and Deployment Configuration

## Containerization of Static Website

I have successfully containerized the `wavy-curvey-blobby-website`, which is a static website that utilizes styled backgrounds with curves, waves, and blobs. The site is designed to be served using a static file server and does not require any third-party services like databases.

- Created a `Dockerfile.static-backgrounds` to build the static website using Nginx.
- Ensured that the Dockerfile copies all necessary files into the Nginx HTML directory and exposes port 80.
- Verified that the Nginx server starts successfully and is ready to serve the static content without any errors.

## Monk.io Configuration

I have also added the necessary Monk.io configuration files to manage the deployment of the static website.

- Added `monk.yaml` which contains the Monk configuration for the service.
- Included a `MANIFEST` file that lists all files containing Monk configurations.

## Deployment Readiness

The static website is ready to be deployed. The Dockerfile and Monk.io configurations are set up correctly, and the service is functioning as expected in isolation. The container logs indicate that Nginx started successfully, and there are no error messages.

- No environment variables or connections to other services are required for the `static-backgrounds` service.
- The service exposes port 80 for HTTP traffic, and no further configuration is necessary.

To proceed with the deployment, simply merge this PR, and the application will be re-deployed on each subsequent push.