### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.static-website
+++ b/Dockerfile.static-website
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+EXPOSE 80

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO wavy-curvey-blobby-website
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,30 @@
+namespace: wavy-curvey-blobby-website
+
+static-website:
+  defines: runnable
+  metadata:
+    name: static-website
+    description: >-
+      A static website showcasing background styles with curves, waves, and
+      blobs.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    static-website:
+      image: env-3296.registry.local/static-website:main-86203a0
+      build: .
+      dockerfile: Dockerfile.static-website
+  services:
+    http:
+      description: Port for serving the static website over HTTP
+      container: static-website
+      port: 80
+      host-port: 80
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - wavy-curvey-blobby-website/static-website


### PR DESCRIPTION
# Containerization and Deployment Configuration for Static Website

## Changes Made

- **Dockerfile Creation**: I created a `Dockerfile.static-website` to containerize the static website. This Dockerfile is based on `nginx:alpine` and is configured to serve the static files on port 80.
- **Monk.io Configuration**: Added a `monk.yaml` file to define the Monk.io deployment configuration and a `MANIFEST` file to list all files containing Monk configurations.
- **Service Analysis**: Confirmed that the static website does not require any backend services, databases, or environment variables. It is a front-end only application that serves static HTML, CSS, and SVG files.

## Deployment Instructions

- **Static Website**: The static website is ready to be deployed using the provided Dockerfile. It serves static content using Nginx and does not require any additional environment variables or connections to other services.
- **Port Information**: The service exposes port 80 for HTTP traffic. No additional ports or configurations are required.

## Next Steps

- **Merge PR**: The PR can be merged to enable re-deployment of the application on each subsequent push.
- **No Further Services**: There are no additional services to compose at this time. If more services are added in the future, further analysis and configuration will be required.

The static website is now containerized and ready for deployment with the provided configurations.