### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.static-backgrounds
+++ b/Dockerfile.static-backgrounds
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+EXPOSE 80

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO wavy-curvey-blobby-website
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: wavy-curvey-blobby-website
+
+static-backgrounds:
+  defines: runnable
+  metadata:
+    name: static-backgrounds
+    description: A static website showcasing various background designs using SVG graphics.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    static-backgrounds:
+      image: env-3296.registry.local/static-backgrounds:main-86203a0
+      build: .
+      dockerfile: Dockerfile.static-backgrounds
+  services:
+    http:
+      description: HTTP web server port
+      container: static-backgrounds
+      port: 80
+      host-port: 80
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - wavy-curvey-blobby-website/static-backgrounds


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for Static Website

## Changes Made

- **Dockerfile Creation**: I created a Dockerfile named `Dockerfile.static-backgrounds` to containerize the static website. The Dockerfile uses `nginx:alpine` as a base image, copies the static assets into the nginx HTML directory, and exposes port 80.
- **Monk.io Configuration**: Added a `monk.yaml` file to define the Monk.io deployment configuration and a `MANIFEST` file to list all files containing Monk configurations.
- **Service Verification**: Verified that the static website, which showcases SVG graphics, does not require any backend connections, environment variables, or additional ports beyond the standard port 80 for serving static content.

## Deployment Instructions

- **Merge PR**: To deploy the application, simply merge this PR. The application will be re-deployed on each subsequent push.
- **No Additional Configuration**: There are no environment variables or connections specified in the Dockerfile, and the service is designed to serve content on port 80 using Nginx. No further action is required for deployment.

## Notes

- The static website is designed to be served without any server-side processing or third-party services like databases.
- The service logs indicate normal operation of the Nginx server, with no errors reported.
- The repository contains only static assets, including an 'index.html' and various SVG files, suitable for a static web server container.

Please review the changes and proceed with merging to deploy the static website.