### PR TITLE
Monk: Add Monk Kit on main branch

### DIFF
--- a/Dockerfile.static-website
+++ b/Dockerfile.static-website
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+EXPOSE 80

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO wavy-curvey-blobby-website
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,30 @@
+namespace: wavy-curvey-blobby-website
+
+static-website:
+  defines: runnable
+  metadata:
+    name: static-website
+    description: >-
+      A static website showcasing background styles with curves, waves, and
+      blobs
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    static-website:
+      image: env-3296.registry.local/static-website:main-86203a0
+      build: .
+      dockerfile: Dockerfile.static-website
+  services:
+    http:
+      description: HTTP port for serving the static website
+      container: static-website
+      port: 80
+      host-port: 80
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - wavy-curvey-blobby-website/static-website


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for Static Website

## Changes Made

- **Dockerfile Creation**: I created a `Dockerfile.static-website` to containerize the static website. This Dockerfile uses `nginx:alpine` as a base image to serve the HTML/CSS files on port 80.
- **Monk.io Configuration**: Added a `monk.yaml` file to define the Monk.io deployment configuration and a `MANIFEST` file to list all files containing Monk configurations.
- **Service Configuration**: Configured the static-website service to be self-contained with no backend or external service dependencies. It exposes port 80 using TCP to serve the static content.

## Summary

The static website, which showcases various background styles using curves, waves, and blobs, is now containerized using Nginx to serve its content. The Dockerfile and Monk.io configurations are set up correctly, and the service is ready to be deployed. There are no environment variables or connections to other services, making the deployment straightforward.

## Instructions for Continuation

- **Merge PR**: The only action required now is to merge this PR. Upon merging, the application will be re-deployed on each subsequent push.
- **No Further Actions**: There are no incomplete tasks or additional configurations needed for the static-website service.

The containerization process has been successful, and the static website should operate correctly when deployed in an environment with the necessary dependencies and configurations.